### PR TITLE
Move logic for assigning properties to parent class to DRY up code.

### DIFF
--- a/includes/models/Model.php
+++ b/includes/models/Model.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MyBBApi\Models;
+
+abstract class Model
+{
+	public function __construct( $args ) {
+		foreach ($args as $key => $value) {
+			$this->{$key} = $value;
+		}
+	}
+}

--- a/includes/models/category.php
+++ b/includes/models/category.php
@@ -1,11 +1,8 @@
 <?php
 
-class Category
+namespace MyBBApi\Models;
+
+class Category extends Model
 {
-	
-	function __construct( $args ) {
-		foreach ($args as $key => $value) {
-			$this->{$key} = $value;
-		}
-	}
+
 }

--- a/includes/models/member.php
+++ b/includes/models/member.php
@@ -1,11 +1,8 @@
 <?php
 
-class Member
+namespace MyBBApi\Models;
+
+class Member extends Model
 {
 	
-	function __construct( $args ) {
-		foreach ($args as $key => $value) {
-			$this->{$key} = $value;
-		}
-	}
 }

--- a/includes/models/reply.php
+++ b/includes/models/reply.php
@@ -1,11 +1,8 @@
 <?php
 
-class Reply
+namespace MyBBApi\Models;
+
+class Reply extends Model
 {
 	
-	function __construct( $args ) {
-		foreach ($args as $key => $value) {
-			$this->{$key} = $value;
-		}
-	}
 }

--- a/includes/models/topic.php
+++ b/includes/models/topic.php
@@ -1,11 +1,8 @@
 <?php
 
-class Topic
+namespace MyBBApi\Models;
+
+class Topic extends Model
 {
-	
-	function __construct( $args ) {
-		foreach ($args as $key => $value) {
-			$this->{$key} = $value;
-		}
-	}
+
 }


### PR DESCRIPTION
Moves all the logic of assigning properties from the constructor into a parent class so the logic isn't repeated throughout models.